### PR TITLE
Add some additional features based on WT:SPI discussion

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Mz7
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/run_bot.py
+++ b/run_bot.py
@@ -152,7 +152,7 @@ def sort_cases(cases):
 	return sorted(cases, key=lambda case: (rank[case['status']], case['file_time']))
 
 
-def get_all_cases():
+def get_all_cases(clerks):
 	cat = pywikibot.Category(site, 'Category:Open SPI cases')
 	gen = pagegenerators.CategorizedPageGenerator(cat)
 	cases = []
@@ -172,7 +172,7 @@ def get_all_cases():
 
 def main():
 	clerks = get_clerk_list()
-	cases = get_all_cases()
+	cases = get_all_cases(clerks)
 	page = pywikibot.Page(site, TABLE_LOCATION)
 	page.text = generate_case_table(cases)
 	page.save(summary='Updating SPI case list ({0} open cases)'.format(len(cases)), minor=False)

--- a/run_bot.py
+++ b/run_bot.py
@@ -3,7 +3,7 @@ from pywikibot import pagegenerators, textlib
 import re
 
 site = pywikibot.Site('en', 'wikipedia')
-TABLE_LOCATION = 'User:Mz7/SPI case list (new order)'  # location where this program should post the SPI case list
+TABLE_LOCATION = 'User:Mz7/SPI case list'  # location where this program should post the SPI case list
 
 
 def get_clerk_list():
@@ -165,8 +165,13 @@ def get_all_cases(clerks):
 				case_copy['status'] = status
 				cases.append(case_copy)
 		else:
-			case['status'] = case['status'][0]
-			cases.append(case)
+			try:
+				case['status'] = case['status'][0]
+				cases.append(case)
+			except IndexError as e:
+				print(e)
+				print("The following case may have been archived while the case details were being grabbed:")
+				print(case)
 	return sort_cases(cases)
 
 
@@ -175,7 +180,7 @@ def main():
 	cases = get_all_cases(clerks)
 	page = pywikibot.Page(site, TABLE_LOCATION)
 	page.text = generate_case_table(cases)
-	page.save(summary='Updating SPI case list ({0} open cases)'.format(len(cases)), minor=False)
+	page.save(summary='Updating SPI case list ({0} active reports)'.format(len(cases)), minor=False)
 
 
 main()

--- a/run_bot.py
+++ b/run_bot.py
@@ -61,7 +61,7 @@ def get_status_from_categories(categories):
 			misc_only.append(status)
 	if curequest_only:
 		result.append(min(curequest_only, key=lambda x: curequest[x]))
-	if misc_only:
+	if misc_only and len(result) == 0:
 		result.append(min(misc_only, key=lambda x: misc[x]))
 	return result
 
@@ -143,12 +143,12 @@ def generate_case_table(cases):
 def sort_cases(cases):
 	"""
 	Order of the SPI case table:
-	inprogress, endorsed, relisted, CUrequest, checked, open, admin, clerk, moreinfo,
-	declined, cudeclined, hold, cuhold, close
+	inprogress > endorsed > relist > CUrequest > admin > clerk > checked > open > cudeclined >
+	declined > moreinfo > cuhold > hold > close
 	"""
-	rank = {'inprogress': 0, 'endorsed': 1, 'relisted': 2, 'CUrequest': 3, 'checked': 4,
-	'open': 5, 'admin': 6, 'clerk': 7, 'moreinfo': 8, 'declined': 9, 'cudeclined': 10, 'hold': 11,
-	'cuhold': 12, 'close': 13}
+	rank = {'inprogress': 0, 'endorsed': 1, 'relisted': 2, 'CUrequest': 3, 'admin': 4,
+	'clerk': 5, 'checked': 6, 'open': 7, 'cudeclined': 8, 'declined': 9, 'moreinfo': 10, 'cuhold': 11,
+	'hold': 12, 'close': 13}
 	return sorted(cases, key=lambda case: (rank[case['status']], case['file_time']))
 
 

--- a/run_bot.py
+++ b/run_bot.py
@@ -189,7 +189,7 @@ def main():
 	cases = get_all_cases(clerks)
 	page = pywikibot.Page(site, TABLE_LOCATION)
 	page.text = generate_case_table(cases)
-	page.save(summary='Updating SPI case list ({0} active reports)'.format(len(cases)), minor=False, bot=True)
+	page.save(summary='Updating SPI case list ({0} active reports)'.format(len(cases)), minor=False, botflag=True)
 
 
 main()

--- a/run_bot.py
+++ b/run_bot.py
@@ -23,6 +23,15 @@ def get_clerk_list():
 
 
 def get_status_from_categories(categories):
+	"""
+	For concision, cases will usually appear in the SPI case table only once, except that
+	the following statuses will always appear: clerk, admin, checked, close, and one of 
+	(inprogress, endorsed, relist, CUrequest).
+	
+	For example, if an SPI case has five active reports, one with 'clerk', one with 'close'
+	one with 'endorsed', one with 'CUrequest', and one with 'open', it will appear three times
+	in the table as 'clerk', 'close', and 'endorsed'.
+	"""
 	print("Getting case status")
 	cat2status = {
 		'SPI cases currently being checked': 'inprogress',
@@ -180,7 +189,7 @@ def main():
 	cases = get_all_cases(clerks)
 	page = pywikibot.Page(site, TABLE_LOCATION)
 	page.text = generate_case_table(cases)
-	page.save(summary='Updating SPI case list ({0} active reports)'.format(len(cases)), minor=False)
+	page.save(summary='Updating SPI case list ({0} active reports)'.format(len(cases)), minor=False, bot=True)
 
 
 main()


### PR DESCRIPTION
Permalink: https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Sockpuppet_investigations&oldid=1024811895#Amaltheabot_malfunctioning

- Cases may now appear multiple times in the table depending on their status
- The SPI table is now ordered such that certain priority statuses appear at the top, e.g. clerk and admin